### PR TITLE
Make Hashing Algorithm Faster (but dumber)

### DIFF
--- a/cubes.py
+++ b/cubes.py
@@ -169,7 +169,7 @@ def rle(polycube):
     data = 0
     for part in pack_cube:
         data = (data << 8) + int(part)
-    out = (data * 100000) + (polycube.shape[0] * 1000) + (polycube.shape[1] * 10) + (polycube.shape[2]) # add volume dimensions to lower bits of hash
+    out = (data * 100000000) + (polycube.shape[0] * 100000) + (polycube.shape[1] * 100) + (polycube.shape[2]) # add volume dimensions to lower bits of hash
     return out
 
 

--- a/cubes.py
+++ b/cubes.py
@@ -151,40 +151,27 @@ def generate_polycubes(n, use_cache=False):
 
 def rle(polycube):
     """
-    Computes a simple run-length encoding of a given polycube. This function allows cubes to be more quickly compared via hashing.
+    Computes a simple hash of a given polycube.
+    It does this by converting the polycube into a 1d array and then interpreting those bits as a unsigned integer
+    This function allows cubes to be more quickly compared via hashing.
   
-    Converts a {0,1} nd array into a tuple that encodes the same shape. The array is first flattened, and then the following algorithm is applied:
-
-    1) The first three values in tuple contain the x,y,z dimension sizes of the array
-    2) Each string of zeros of length n is replaced with a single value -n
-    3) Each string of ones of length m is replaced with a single value +m
+    Converts a {0,1} nd array into a single unique large integer
   
     Parameters:
     polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
   
     Returns:
-    tuple(int): Run length encoded polycube in the form (X, Y, Z, a, b, c, ...)
+    int: a unique integer hash
 
     """
-    r = []
-    r.extend(polycube.shape)
-    current = None
-    val = 0
-    for x in polycube.flat:
-        if current is None:
-            current = x
-            val = 1
-            pass
-        elif current == x:
-            val += 1
-        elif current != x:
-            r.append(val if current == 1 else -val)
-            current = x
-            val = 1
 
-    r.append(val if current == 1 else -val)
+    pack_cube = np.packbits(polycube.flatten())
+    out = 0
+    for part in pack_cube:
+        out = out * 256
+        out += int(part)
+    return out
 
-    return tuple(r)
 
 def cube_exists_rle(polycube, polycubes_rle):
     """

--- a/cubes.py
+++ b/cubes.py
@@ -149,7 +149,7 @@ def generate_polycubes(n, use_cache=False):
 
     return polycubes
 
-def rle(polycube):
+def rle(polycube: np.ndarray):
     """
     Computes a simple hash of a given polycube.
     It does this by converting the polycube into a 1d array and then interpreting those bits as a unsigned integer
@@ -166,10 +166,10 @@ def rle(polycube):
     """
 
     pack_cube = np.packbits(polycube.flatten())
-    out = 0
+    data = 0
     for part in pack_cube:
-        out = out * 256
-        out += int(part)
+        data = (data << 8) + int(part)
+    out = (data * 100000) + (polycube.shape[0] * 1000) + (polycube.shape[1] * 10) + (polycube.shape[2]) # add volume dimensions to lower bits of hash
     return out
 
 

--- a/cubes.py
+++ b/cubes.py
@@ -149,7 +149,7 @@ def generate_polycubes(n, use_cache=False):
 
     return polycubes
 
-def rle(polycube: np.ndarray):
+def rle(polycube):
     """
     Computes a simple hash of a given polycube.
     It does this by converting the polycube into a 1d array and then interpreting those bits as a unsigned integer


### PR DESCRIPTION
Hi just wanted to contribute with the first of a few optimizations I have made.

Please let me know if you actually want this kind of contribution before I raise more of these, namely I will be focusing on more runtime optimizations and parallelism than on the pure math's question of how to sort out the cube rotations.

as such this isn't a pure math optimization, in fact it technically creates more data, but it does more of the work in numpy in C and so is much quicker.

instead of hashing with your RLE, we convert the bits straight into unsigned ints with np.packbits, then we concatenate these ints into a single python int object for the hash.

finally, we add the dimensions of the array to the lowest part of the integer so we don't lose that information.

benchmark attached for n=10 (absolute time is irrelevant as hardware dependent but their is a 2x speedup from the old code)

PS C:\Users\georg\orig_cubes> python.exe .\cubes.py --no-cache 10
Generating polycubes n=3: 100%   
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%   
Generating polycubes n=6: 100%   
Generating polycubes n=7: 100%   
Generating polycubes n=8: 100%   
Generating polycubes n=9: 100%   
Generating polycubes n=10: 100%   
Found 346543 unique polycubes
Elapsed time: 450.932s

PS C:\Users\georg\orig_cubes> python.exe .\improved_hash.py --no-cache 10
Generating polycubes n=3: 100%   
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%   
Generating polycubes n=6: 100%   
Generating polycubes n=7: 100%   
Generating polycubes n=8: 100%   
Generating polycubes n=9: 100%   
Generating polycubes n=10: 100%   
Found 346543 unique polycubes
Elapsed time: 230.274s

unfortunately since this is speeding up hashing itself not the searches, it will only be a linear speed up so will only push us slightly higher on maximum N.