### PR TITLE
Find the polycube in crop_cube to remove padding

### DIFF
--- a/cubes.py
+++ b/cubes.py
@@ -54,12 +54,10 @@ def crop_cube(cube):
   
     """
     for i in range(cube.ndim):
-        cube = np.swapaxes(cube, 0, i)  # send i-th axis to front
-        while np.all( cube[0]==0 ):
-            cube = cube[1:]
-        while np.all( cube[-1]==0 ):
-            cube = cube[:-1]
-        cube = np.swapaxes(cube, 0, i)  # send i-th axis to its original position
+        cube = np.swapaxes(cube, 0, i)
+        nonzero_indices = np.any(cube != 0, axis=tuple(range(1, cube.ndim)))
+        cube = cube[nonzero_indices]
+        cube = np.swapaxes(cube, 0, i)
     return cube
 
 def expand_cube(cube):

--- a/cubes.py
+++ b/cubes.py
@@ -133,8 +133,7 @@ def generate_polycubes(n, use_cache=False):
         for new_cube in expand_cube(base_cube):
             if not cube_exists_rle(new_cube, polycubes_rle):
                 polycubes.append(new_cube)
-                for cube_rotation in all_rotations(new_cube):
-                    polycubes_rle.add(rle(cube_rotation))
+                polycubes_rle.add(rle(new_cube))
 
         if (idx % 100 == 0):               
             perc = round((idx / len(base_cubes)) * 100,2)
@@ -150,25 +149,40 @@ def generate_polycubes(n, use_cache=False):
 
 def rle(polycube):
     """
-    Computes a simple hash of a given polycube.
-    It does this by converting the polycube into a 1d array and then interpreting those bits as a unsigned integer
-    This function allows cubes to be more quickly compared via hashing.
+    Computes a simple run-length encoding of a given polycube. This function allows cubes to be more quickly compared via hashing.
   
-    Converts a {0,1} nd array into a single unique large integer
+    Converts a {0,1} nd array into a tuple that encodes the same shape. The array is first flattened, and then the following algorithm is applied:
+
+    1) The first three values in tuple contain the x,y,z dimension sizes of the array
+    2) Each string of zeros of length n is replaced with a single value -n
+    3) Each string of ones of length m is replaced with a single value +m
   
     Parameters:
     polycube (np.array): 3D Numpy byte array where 1 values indicate polycube positions
   
     Returns:
-    int: a unique integer hash
-    """
+    tuple(int): Run length encoded polycube in the form (X, Y, Z, a, b, c, ...)
 
-    pack_cube = np.packbits(polycube.flatten())
-    data = 0
-    for part in pack_cube:
-        data = (data << 8) + int(part)
-    out = (data * 100000000) + (polycube.shape[0] * 100000) + (polycube.shape[1] * 100) + (polycube.shape[2]) # add volume dimensions to lower bits of hash
-    return out
+    """
+    r = []
+    r.extend(polycube.shape)
+    current = None
+    val = 0
+    for x in polycube.flat:
+        if current is None:
+            current = x
+            val = 1
+            pass
+        elif current == x:
+            val += 1
+        elif current != x:
+            r.append(val if current == 1 else -val)
+            current = x
+            val = 1
+
+    r.append(val if current == 1 else -val)
+
+    return tuple(r)
 
 def cube_exists_rle(polycube, polycubes_rle):
     """
@@ -184,7 +198,11 @@ def cube_exists_rle(polycube, polycubes_rle):
     boolean: True if polycube is already present in the set of all cubes so far.
   
     """
-    return rle(polycube) in polycubes_rle
+    for cube_rotation in all_rotations(polycube):
+        if rle(cube_rotation) in polycubes_rle:
+            return True
+
+    return False
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Avoids the extremely slow usage of while loops by finding where the polycube is rather than where it isn't. I haven't extensively tested it to ensure it is working correctly.

```
cubes.py --no-cache 9
Generating polycubes n=3: 100%
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%
Generating polycubes n=6: 100%
Generating polycubes n=7: 100%
Generating polycubes n=8: 100%
Generating polycubes n=9: 100%
Found 48311 unique polycubes
Elapsed time: 84.735s
```

**With faster crop:**

```
cubes.py --no-cache 9
Generating polycubes n=3: 100%
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%
Generating polycubes n=6: 100%
Generating polycubes n=7: 100%
Generating polycubes n=8: 100%
Generating polycubes n=9: 100%
Found 48311 unique polycubes
Elapsed time: 76.839s
```

**With bertie2 and georgedorn optimisations:**

```
python cubes.py --no-cache 9
Generating polycubes n=3: 100%
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%
Generating polycubes n=6: 100%
Generating polycubes n=7: 100%
Generating polycubes n=8: 100%
Generating polycubes n=9: 100%
Found 48311 unique polycubes
Elapsed time: 35.043s
```

**With bertie2 and georgedorn optimisations and faster crop:**
```
python cubes.py --no-cache 9
Generating polycubes n=3: 100%
Generating polycubes n=4: 100%
Generating polycubes n=5: 100%
Generating polycubes n=6: 100%
Generating polycubes n=7: 100%
Generating polycubes n=8: 100%
Generating polycubes n=9: 100%
Found 48311 unique polycubes
Elapsed time: 26.828s
```